### PR TITLE
header icon and cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,24 @@
 # Auto Select Active Strip
+
 Blender VSE: Snippet to auto select active strip and all strips below it at the current playhead position. This can be very useful when ex. colorgrading or making a lot of splits under the playhead.
 
-# Installation:
-Donwload this: https://github.com/tin2tin/auto_select_active_strip/archive/refs/heads/main.zip
+## Installation
 
-# Find it here:
+Download this: https://github.com/tin2tin/auto_select_active_strip/archive/refs/heads/main.zip
+
+## Find it here
+
+Header: Right side of header
+
 Menu: Sequencer > Select > Auto-Select
 
 Panel: Sidebar(N) > Tool > Auto Select
 
-# Auto-selection while playing(for ex. color grading):
+## Auto-selection while playing(for ex. color grading)
+
 ![alt text](https://github.com/tin2tin/auto_select_active_strip/blob/main/auto_select.gif?raw=true)
 
 
-# Quick trim without manual selection:
+## Quick trim without manual selection
+
 ![alt text](https://github.com/tin2tin/auto_select_active_strip/blob/main/auto_select_trim.gif?raw=true)

--- a/README.md
+++ b/README.md
@@ -8,11 +8,11 @@ Download this: https://github.com/tin2tin/auto_select_active_strip/archive/refs/
 
 ## Find it here
 
-Header: Right side of header
+Header: Toggle and Pop-over at right side of header
 
-Menu: Sequencer > Select > Auto-Select
+<!-- Menu: Sequencer > Select > Auto-Select -->
 
-Panel: Sidebar(N) > Tool > Auto Select
+<!-- Panel: Sidebar(N) > Tool > Auto Select -->
 
 ## Auto-selection while playing(for ex. color grading)
 

--- a/__init__.py
+++ b/__init__.py
@@ -3,7 +3,7 @@
 bl_info = {
     "name": "Auto-select strips under the playhead",
     "author": "Tintwotin, Samuel Bernou",
-    "version": (1, 3),
+    "version": (1, 4),
     "blender": (2, 90, 0),
     "location": "Sequencer > Select > Auto-Select & Sidebar > Auto Select",
     "description": "Auto-selects strips under the playhead.",
@@ -53,7 +53,6 @@ class autoselect_property_group(PropertyGroup):
 
 @persistent
 def auto_select_active_strip(scene):
-    # print(bpy.context.scene.auto_select_strip.auto_select_toggle)
     if bpy.context.scene.auto_select_strip.auto_select_toggle == False:
         return
     settings = bpy.context.scene.auto_select_strip
@@ -99,14 +98,12 @@ class SEQUENCER_PT_auto_select_ui(Panel):
     bl_space_type = "SEQUENCE_EDITOR"
     bl_region_type = "UI"
     bl_category = "Tool"
+    bl_options = {"INSTANCED"}
 
     def draw_header(self, context):
         settings = context.scene.auto_select_strip
-        if context.region.type == 'HEADER':
-            ico = 'RESTRICT_SELECT_OFF' if settings.auto_select_toggle else 'RESTRICT_SELECT_ON'
-            self.layout.prop(settings, "auto_select_toggle", text="", icon=ico)
-        else:
-            self.layout.prop(settings, "auto_select_toggle", text="")
+        ico = 'RESTRICT_SELECT_OFF' if settings.auto_select_toggle else 'RESTRICT_SELECT_ON'
+        self.layout.prop(settings, "auto_select_toggle", text="", icon=ico)
 
     def draw(self, context):
         settings = context.scene.auto_select_strip
@@ -140,8 +137,8 @@ def register():
     for cls in classes:
         bpy.utils.register_class(cls)
     bpy.types.Scene.auto_select_strip = PointerProperty(type=autoselect_property_group)
-    bpy.types.SEQUENCER_MT_context_menu.append(menu_auto_select)
-    bpy.types.SEQUENCER_MT_select.append(menu_auto_select)
+    # bpy.types.SEQUENCER_MT_context_menu.append(menu_auto_select)
+    # bpy.types.SEQUENCER_MT_select.append(menu_auto_select)
     bpy.types.SEQUENCER_HT_header.append(menu_auto_select) 
     bpy.app.handlers.frame_change_post.append(auto_select_active_strip)
 
@@ -149,8 +146,8 @@ def register():
 def unregister():
 
     del bpy.types.Scene.auto_select_strip
-    bpy.types.SEQUENCER_MT_context_menu.remove(menu_auto_select)
-    bpy.types.SEQUENCER_MT_select.remove(menu_auto_select)
+    # bpy.types.SEQUENCER_MT_context_menu.remove(menu_auto_select)
+    # bpy.types.SEQUENCER_MT_select.remove(menu_auto_select)
     bpy.types.SEQUENCER_HT_header.remove(menu_auto_select)
     bpy.app.handlers.frame_change_post.remove(auto_select_active_strip)
     for cls in reversed(classes):


### PR DESCRIPTION
Hi again,
The only thing that bothered me a little in the last UI update was the aspect of the checkbox in the header
So here is a new one:

![image](https://user-images.githubusercontent.com/7763187/193454400-459493a0-70a1-4564-86f4-6afaabf70fe9.png)

While I was there, I did some "cosmetic" code changes, hope you won't mind !
Here is the list :
- added icon for autoselect header
- use short identifier for license block
- renamed propertyGroup class name
- removed unused code
- added doc url
- remove trailing whitespaces

On the readme file:
- added header location
- slight markdown reformat

